### PR TITLE
An alternative approach which avoids adding/changing methods to/in String and Array

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+Gemfile.lock
 .DS_Store
 *.tmproj
 taggart_notes.txt

--- a/Gemfile
+++ b/Gemfile
@@ -1,0 +1,7 @@
+source 'https://rubygems.org'
+
+gemspec
+
+# gem "guard"
+# gem "guard-rspec"
+# gem "rb-fsevent" # rb-fsevent is only required on MacOS.

--- a/README.markdown
+++ b/README.markdown
@@ -3,7 +3,8 @@ Taggart surrounds your strings with HTML Tags
 How and what
 ------------
 ```ruby
-  "Hello World!".h1
+  include Taggart::API
+  taggart("Hello World!").h1.to_s
 ```
 
 returns
@@ -15,7 +16,7 @@ returns
 or try (in bad typographical taste) 
 
 ```ruby
-  "Important!".em.strong
+  taggart("Important!").em.strong.to_s
 ```
 
 to get 
@@ -27,7 +28,7 @@ to get
 or do some more nesting 
 
 ```ruby
-  ("Label".td + "Value".td).tr.table
+  (taggart("Label").td + taggart("Value").td).tr.table.to_s
 ```
 
 to render a small table
@@ -39,7 +40,7 @@ to render a small table
 Add HTML attributes as Ruby parameters.
 
 ```ruby
-  "hello".span(class: 'stuff', id: 'thing')
+  taggart("hello").span(class: 'stuff', id: 'thing').to_s
 ```
 
 to get a nice HTML string like this
@@ -51,7 +52,7 @@ to get a nice HTML string like this
 You can also use arrays, how about this table?
 
 ```ruby
-  (%w(r1c1 r1c2 r1c3).td.tr + %w(r2c1 r2c2 r2c3).td.tr).table
+  (taggart(%w(r1c1 r1c2 r1c3)).td.tr + taggart(%w(r2c1 r2c2 r2c3)).td.tr).table.to_s
 ```
 
 will produce this HTML (author's line breaks and indentation)
@@ -74,7 +75,7 @@ will produce this HTML (author's line breaks and indentation)
 Naturally we can do single tags too.
 
 ```ruby
-  "Gimme a".br
+  taggart("Gimme a").br.to_s
 ```
 
 will return.
@@ -89,7 +90,7 @@ Also try some of the 'cleverness', for example calling `.script` on a `.js` file
 Like this:
 
 ```ruby
-  "alert('This string will pop up an alert!')".script
+  taggart("alert('This string will pop up an alert!')").script.to_s
 ```
 
 gives you
@@ -101,7 +102,7 @@ gives you
 whereas this string
 
 ```ruby
-  "/script/awesome_script.js".script
+  taggart("/script/awesome_script.js").script.to_s
 ```
 
 gives you this
@@ -113,7 +114,7 @@ gives you this
 Calling `.ol` or `.ul` on an array, will generate a full ordered or unordered list, like this
 
 ```ruby
-  %w(First Second Third).ol
+  taggart(%w(First Second Third)).ol
 ```
 
 returns
@@ -150,7 +151,7 @@ It's not particularly nice to write `"<strong>#{my_variable}</strong>"`. The mor
 complex the Ruby code is, the worse it is to have `"`, `#`, `{` or `}` soiling the code.
 I was looking at the code and I thought, wouldn't it be nice if I could just tell that piece
 of String that it's supposed to be a `<span>` or some other tag. One could simply 
-write `my_variable.strong` to get the job done. **Taggart** was born.
+write `taggart(my_variable).strong.to_s` to get the job done. **Taggart** was born.
 
 The Idea
 --------

--- a/lib/taggart.rb
+++ b/lib/taggart.rb
@@ -52,10 +52,6 @@ module Taggart
     Taggart::String::STANDARD_TAGS
   end
 
-  def self.special_tags
-    Taggart::String::SPECIAL_TAGS
-  end
-
   def self.single_tags
     Taggart::String::SINGLE_TAGS 
   end
@@ -104,8 +100,7 @@ module Taggart
                         section select small source span strong style sub summary sup table tbody td textarea 
                         tfoot th thead time title tr track tt ul video wbr} # This is not a complete list - please tweet or pull req.
 
-    SPECIAL_TAGS  = []
-    TAGS = STANDARD_TAGS + SPECIAL_TAGS
+    TAGS = STANDARD_TAGS
     SINGLE_TAGS = %w{br hr input link meta}
 
     def initialize(string)

--- a/lib/taggart.rb
+++ b/lib/taggart.rb
@@ -15,6 +15,18 @@ module Taggart
   CLOSED_TAG = ' /'
   OPEN_TAG = ''
 
+  module API
+    def taggart(object)
+      case object
+      when ::String
+        Taggart::String.new(object)
+      when ::Array
+        Taggart::Array.new(object)
+      else
+        raise "Taggart: #{object.class} not supported"
+      end
+    end
+  end
 
   def initialize
     @current_close_tag = OPEN_TAG
@@ -81,72 +93,59 @@ module Taggart
 
   private
 
-  module String
+  class String
+    include API
   
     DEBUG = false
     STANDARD_TAGS = %w{ a abbr acronym address article aside audio bdi blockquote body button canvas 
                         caption cite code command datalist dd del details div dl dt em embed fieldset 
                         figcaption figure footer form h1 h2 h3 h4 h5 h6 head header hgroup html keygen 
                         label legend li mark meter nav ol option output p pre progress q rp rt ruby 
-                        section select small source span strong style summary sup table tbody td textarea 
-                        tfoot th thead time title track tt ul video wbr} # This is not a complete list - please tweet or pull req.
+                        section select small source span strong style sub summary sup table tbody td textarea 
+                        tfoot th thead time title tr track tt ul video wbr} # This is not a complete list - please tweet or pull req.
 
-    SPECIAL_TAGS  = [['tr', '_tr'], ['sub', '_sub']]
+    SPECIAL_TAGS  = []
     TAGS = STANDARD_TAGS + SPECIAL_TAGS
     SINGLE_TAGS = %w{br hr input link meta}
 
-    # Redefining <tr> to work with both translate-tr and tag-tr
-    def dual_tr(*args)
-      if ((args.size == 2) && (args[0].is_a? String) && (args[1].is_a? String))
-        self.translate(args[0], args[1])
-      else
-        self._tr(args.first)
-      end
+    def initialize(string)
+      @string = string
     end
-
-
-    # Redefining <sub> to work with both substitute-sub and tag-sub
-    def dual_sub(*args, &block)
-      if (args[0].is_a? Hash)
-        self._sub(args.first)
-      elsif args.empty?
-        self._sub
-      else
-        if block_given?
-          self.substitute(args[0]) { |*args| block.call(*args) }
-        else
-          self.substitute(args[0], args[1])
-        end
-      end
-    end
-    
 
     def href(label = nil, *args)
-      option_str = parse_options(args << {href: self})
-      label ||= self
-      "<a#{option_str}>#{label}</a>"
+      option_str = parse_options(args << {href: @string})
+      label ||= @string
+      taggart("<a#{option_str}>#{label}</a>")
     end
     
     
     def img(*args)
-      option_str = parse_options(args << {src: self})
-      "<img#{option_str} />"
+      option_str = parse_options(args << {src: @string})
+      taggart("<img#{option_str} />")
     end
     
     
     def script(*args)
-      if self[-3, 3] == '.js' # We've got a Jabbarscript file (could/should cater for all script types. VBScript, heheeh!)
-        option_str = parse_options(args << {type: "text/javascript", src: self})
-        "<script#{option_str}></script>"
+      if @string[-3, 3] == '.js' # We've got a Jabbarscript file (could/should cater for all script types. VBScript, heheeh!)
+        option_str = parse_options(args << {type: "text/javascript", src: @string})
+        taggart("<script#{option_str}></script>")
       else
         option_str = parse_options(args << {type: "text/javascript"})
-        "<script#{option_str}>#{self}</script>"
+        taggart("<script#{option_str}>#{@string}</script>")
       end
     end
 
 
     def htji
-      %w{72 101 108 108 111 32 116 111 32 74 97 115 111 110 32 73 115 97 97 99 115 33}.map { |c| c.to_i.chr }.join.h1
+      taggart(%w{72 101 108 108 111 32 116 111 32 74 97 115 111 110 32 73 115 97 97 99 115 33}.map { |c| c.to_i.chr }.join).h1
+    end
+
+    def +(other)
+      taggart(self.to_s + other.to_s)
+    end
+
+    def to_s
+      @string
     end
 
 
@@ -177,7 +176,7 @@ module Taggart
     def self.single_attribute_tag(tag)
       define_method(tag) do |*args|
         option_str = parse_options(args)
-        "#{self}<#{tag}#{option_str}#{Taggart.current_close_tag}>"
+        taggart("#{@string}<#{tag}#{option_str}#{Taggart.current_close_tag}>")
       end
     end
   
@@ -188,7 +187,7 @@ module Taggart
       puts "Defining tag '#{(tag + "',").ljust(12)} with method name: '#{tag_name}'" if DEBUG
       define_method(tag_name) do |*args|
         option_str = parse_options(args)
-        "<#{tag}#{option_str}>#{self}</#{tag}>"
+        taggart("<#{tag}#{option_str}>#{@string}</#{tag}>")
       end
     end
   
@@ -209,11 +208,15 @@ module Taggart
   end # End String module
   
   
-  module Array
+  class Array
+    include API
     
     DEBUG = false
-    
-    
+
+    def initialize(array)
+      @array = array
+    end
+
     # Defines a standard tag that can create attributes
     def self.array_attribute_tag(tag, tag_name = nil)
       tag_name ||= tag
@@ -221,16 +224,16 @@ module Taggart
       define_method(tag_name) do |*args|
         args = args.first if args # Only using the first of the array
         result = []
-        self.each do |object|
-          if object.is_a? String
-            result << object.send(tag_name.to_sym, args)
-          elsif object.is_a? Symbol
-            result << object.to_s.send(tag_name.to_sym, args)
-          elsif object.is_a? Array # I don't know why you'd want to do this, but here it is.
-            result << (object.send(tag_name.to_sym, args)).send(tag_name.to_sym, args)
+        @array.each do |object|
+          if object.is_a? ::String
+            result << taggart(object).send(tag_name.to_sym, args)
+          elsif object.is_a? ::Symbol
+            result << taggart(object.to_s).send(tag_name.to_sym, args)
+          elsif object.is_a? ::Array # I don't know why you'd want to do this, but here it is.
+            result << taggart(object).send(tag_name.to_sym, args).send(tag_name.to_sym, args)
           end
         end
-        result.join
+        taggart(result.join)
       end
     end
     
@@ -242,49 +245,29 @@ module Taggart
     
     
     def ol(*args)
-      self.li.ol(*args)
+      taggart(@array).li.ol(*args)
     end
     
     
     def ul(*args)
-      self.li.ul(*args)
+      taggart(@array).li.ul(*args)
     end
     
     
     def tr(*args)
-      self.td.tr(*args)
+      taggart(@array).td.tr(*args)
     end
     
     
     def table(*args)
-      if self.first.is_a? Array
-        self.map do |table_row|
-          table_row.tr if table_row.is_a? Array
-        end.join.table(*args)
+      if @array.first.is_a? ::Array
+        taggart(@array.map do |table_row|
+          taggart(table_row).tr if table_row.is_a? ::Array
+        end.join).table(*args)
       else
-        self.tr.table(*args)
+        taggart(@array).tr.table(*args)
       end
     end
     
   end # End Array module
-end
-
-
-class String
-  alias_method :translate, :tr
-  alias_method :substitute, :sub
-  include Taggart::String
-
-  def tr(*args) 
-    dual_tr(*args)
-  end
-  
-  def sub(*args, &block) 
-    dual_sub(*args, &block)
-  end
-end
-
-
-class Array
-  include Taggart::Array
 end

--- a/lib/taggart_help.rb
+++ b/lib/taggart_help.rb
@@ -40,18 +40,6 @@ module TaggartHelp
     "These tags have a start- and end-tag and the take any number of\n" +
     "attributes in the form of a hash with key-value pairs.\n" +
     output_tags(Taggart::String::STANDARD_TAGS) +
-    "\nSpecial tags\n" +
-    "------------\n" +
-    "These tags behave like the Standard tags, but there's already a\n" +
-    "method defined for the String instance so these tags have to be\n" +
-    "treated in a slightly special way, in that the tag that's ouputted\n" +
-    "doesn't have the same method name. I.e to output <tr> you call '._tr'\n" +
-    "however, you don't really need to bother with knowing this as Taggart\n" +
-    "does some magic behind the scenes to determine wheter you are asking\n" +
-    "for a Taggart tag or the original method.\n" +
-    (Taggart::String::SPECIAL_TAGS.sort.map do |tag_pair|
-      "  Tag: #{('<' + tag_pair[0] + '>').ljust(6)}  Method: .#{tag_pair[1]}"
-    end).join("\n") +
     "\n\nSingle Tags\n" +
     "-------------\n" +
     "Single tags are tags that do not an end tag, <br> is one such tag\n" +
@@ -98,7 +86,6 @@ module TaggartHelp
     "You can access the following arrays and methods containing the tags.\n" +
     "Tags           Array                            Method\n" +
     "Standard tags  Taggart::String::STANDARD_TAGS   Taggart.standard_tags\n" +
-    "Special tags   Taggart::String::SPECIAL_TAGS    Taggart.special_tags\n" +
     "Single tags    Taggart::String::SINGLE_TAGS     Taggart.single_tags"
   end
 

--- a/spec/lib/taggart_spec.rb
+++ b/spec/lib/taggart_spec.rb
@@ -54,10 +54,6 @@ describe Taggart, "informational" do
     Taggart.standard_tags.should be_an(Array)
   end
 
-  it "returns an array when asked for special tags" do
-    Taggart.special_tags.should be_an(Array)
-  end
-
   it "returns an array when asked for single tags" do
     Taggart.single_tags.should be_an(Array)
   end

--- a/spec/lib/taggart_spec.rb
+++ b/spec/lib/taggart_spec.rb
@@ -91,102 +91,105 @@ describe Taggart, "informational" do
 end
 
 describe Taggart::String, "#attribute_tags" do
-  
+  include Taggart::API
+
   it "returns a standard tag without any attributes" do
-    "hello world".h1.should == '<h1>hello world</h1>'
+    taggart("hello world").h1.to_s.should == '<h1>hello world</h1>'
   end
   
   it "returns a standard tag with one attribute" do
-    "hello world".h1(class: :header).should == "<h1 class=\"header\">hello world</h1>"
+    taggart("hello world").h1(class: :header).to_s.should == "<h1 class=\"header\">hello world</h1>"
   end
   
   it "returns a standard tag with two attribute" do
-    "hello world".h1(class: :header, id: :title).should == "<h1 class=\"header\" id=\"title\">hello world</h1>"
+    taggart("hello world").h1(class: :header, id: :title).to_s.should == "<h1 class=\"header\" id=\"title\">hello world</h1>"
   end
 end
 
 
 describe Taggart::String, "#single_attribute_tag" do
-  
+  include Taggart::API
+
   it "returns a single tag without any attributes" do
-    "hello world".br.should == 'hello world<br />'
+    taggart("hello world").br.to_s.should == 'hello world<br />'
   end
   
   it "returns a standard tag with one attribute" do
-    "hello world".br(class: :header).should == "hello world<br class=\"header\" />"
+    taggart("hello world").br(class: :header).to_s.should == "hello world<br class=\"header\" />"
   end
   
   it "returns a standard tag with two attribute" do
-    "hello world".br(class: :header, id: :title).should == "hello world<br class=\"header\" id=\"title\" />"
+    taggart("hello world").br(class: :header, id: :title).to_s.should == "hello world<br class=\"header\" id=\"title\" />"
   end
   describe "open or closed tag ending" do
     it "returns <br /> when the tag ending is set to closed" do
       Taggart.close_ending_tag
-      "hello world".br.should == 'hello world<br />'
+      taggart("hello world").br.to_s.should == 'hello world<br />'
     end
 
     it "returns <br> when the tag ending is set to open" do
       Taggart.open_ending_tag
-      "hello world".br.should == 'hello world<br>'
+      taggart("hello world").br.to_s.should == 'hello world<br>'
     end
   end
 end
 
 describe Taggart::Array, "#array_attribute_tag" do
+  include Taggart::API
   
   it "returns the elements in the array wrapped with li-tags when calling .li method" do
-    %w{one two three}.li.should == "<li>one</li><li>two</li><li>three</li>"
+    taggart(%w{one two three}).li.to_s.should == "<li>one</li><li>two</li><li>three</li>"
   end
   
   it "returns the elements with an attribute wrapped in td when calling the td method on the array" do
-    %w{one two three}.td(class: :programmers).should == "<td class=\"programmers\">one</td><td class=\"programmers\">two</td><td class=\"programmers\">three</td>"
+    taggart(%w{one two three}).td(class: :programmers).to_s.should == "<td class=\"programmers\">one</td><td class=\"programmers\">two</td><td class=\"programmers\">three</td>"
   end
   
   it "returns the array elements wrapped in td tags and two attributes when called with two attribute parameters" do
-    %w{one two three}.td(class: :programmers, id: :unpossible).should == "<td class=\"programmers\" id=\"unpossible\">one</td><td class=\"programmers\" id=\"unpossible\">two</td><td class=\"programmers\" id=\"unpossible\">three</td>"
+    taggart(%w{one two three}).td(class: :programmers, id: :unpossible).to_s.should == "<td class=\"programmers\" id=\"unpossible\">one</td><td class=\"programmers\" id=\"unpossible\">two</td><td class=\"programmers\" id=\"unpossible\">three</td>"
   end
   
   it "returns the elements in the array wrapped with td when calling the td method" do
-    [:one, :two, :three].td.should == "<td>one</td><td>two</td><td>three</td>"
+    taggart([:one, :two, :three]).td.to_s.should == "<td>one</td><td>two</td><td>three</td>"
   end
   
   it "renders a nested set of td-tags when the td method is called no a nested array" do
-    [:one, [:nine, :eight, :seven], :two, :three].td.should == "<td>one</td><td><td>nine</td><td>eight</td><td>seven</td></td><td>two</td><td>three</td>"
+    taggart([:one, [:nine, :eight, :seven], :two, :three]).td.to_s.should == "<td>one</td><td><td>nine</td><td>eight</td><td>seven</td></td><td>two</td><td>three</td>"
   end
   
   
-  describe Taggart::String, "#dual_tr" do
+  describe Taggart::String, "#tr" do
     it "executes translate-tr when two parameters of string is passed in" do
-      "Jolly Roger".tr('J','G').tr('R', 'B').should == "Golly Boger"
+      "Jolly Roger".tr('J','G').tr('R', 'B').to_s.should == "Golly Boger"
     end
     
     it "executes tag-tr when no parameters are passed in" do
-      "Jolly Roger".tr.should == "<tr>Jolly Roger</tr>"
+      taggart("Jolly Roger").tr.to_s.should == "<tr>Jolly Roger</tr>"
     end
     
     it "executes tag-tr when hash parameters are passed in" do
-      "Jolly Roger".tr(id: :jolly_roger).should == "<tr id=\"jolly_roger\">Jolly Roger</tr>"
+      taggart("Jolly Roger").tr(id: :jolly_roger).to_s.should == "<tr id=\"jolly_roger\">Jolly Roger</tr>"
     end
     
     it "executes translate-tr when the first example from the Ruby documentation is executed" do
-      "hello".tr('el', 'ip').should == "hippo"
+      "hello".tr('el', 'ip').to_s.should == "hippo"
     end
     
     it "executes translate-tr when the second example from the Ruby documentation is executed" do
-      "hello".tr('aeiou', '*').should == "h*ll*"
+      "hello".tr('aeiou', '*').to_s.should == "h*ll*"
     end
     
     it "executes translate-tr when the third example from the Ruby documentation is executed" do
-      "hello".tr('a-y', 'b-z').should == "ifmmp"
+      "hello".tr('a-y', 'b-z').to_s.should == "ifmmp"
     end
     
     it "executes translate-tr when the fourth example from the Ruby documentation is executed" do
-      "hello".tr('^aeiou', '*').should == "*e**o"
+      "hello".tr('^aeiou', '*').to_s.should == "*e**o"
     end
   end
   
   
-  describe Taggart::String, "#dual_sub" do
+  describe Taggart::String, "#sub" do
     it "executes substitute-sub when the first example from the documentation is passed in" do
       "hello".sub(/[aeiou]/, '*').should == "h*llo"
     end
@@ -212,137 +215,143 @@ describe Taggart::Array, "#array_attribute_tag" do
     end
     
     it "executes tag-sub when no parameters are passed in" do
-      "You're just a substitute".sub.should == "<sub>You're just a substitute</sub>"
+      taggart("You're just a substitute").sub.to_s.should == "<sub>You're just a substitute</sub>"
     end
 
     it "executes tag-sub when a hash of attribute-values are passed in" do
-      "You're just a substitute".sub(id: :thingy).should == "<sub id=\"thingy\">You're just a substitute</sub>"
+      taggart("You're just a substitute").sub(id: :thingy).to_s.should == "<sub id=\"thingy\">You're just a substitute</sub>"
     end
     
     it "executes tag-sub when a hash of two attribute-values are passed in" do
-      "You're just a substitute".sub(id: :thingy, class: :lowlowlow).should == "<sub id=\"thingy\" class=\"lowlowlow\">You're just a substitute</sub>"
+      taggart("You're just a substitute").sub(id: :thingy, class: :lowlowlow).to_s.should == "<sub id=\"thingy\" class=\"lowlowlow\">You're just a substitute</sub>"
     end
   end
   
   
   describe Taggart::String, "More complex use" do
+    include Taggart::API
+
     it "builds a small table HTML" do
-      row_1 = %w(r1c1 r1c2 r1c3)
-      row_2 = %w(r2c1 r2c2 r2c3)
-      (row_1.td.tr + row_2.td.tr).table.should == "<table><tr><td>r1c1</td><td>r1c2</td><td>r1c3</td></tr><tr><td>r2c1</td><td>r2c2</td><td>r2c3</td></tr></table>" 
+      row_1 = taggart(%w(r1c1 r1c2 r1c3))
+      row_2 = taggart(%w(r2c1 r2c2 r2c3))
+      (row_1.td.tr + row_2.td.tr).table.to_s.should == "<table><tr><td>r1c1</td><td>r1c2</td><td>r1c3</td></tr><tr><td>r2c1</td><td>r2c2</td><td>r2c3</td></tr></table>" 
     end
     
     it "builds an ordered list HTML" do
-      %w(First Second Third Fourth Fifth Sizt Seventh).li.ol.should == "<ol><li>First</li><li>Second</li><li>Third</li><li>Fourth</li><li>Fifth</li><li>Sizt</li><li>Seventh</li></ol>" 
+      taggart(%w(First Second Third Fourth Fifth Sizt Seventh)).li.ol.to_s.should == "<ol><li>First</li><li>Second</li><li>Third</li><li>Fourth</li><li>Fifth</li><li>Sizt</li><li>Seventh</li></ol>" 
     end
   end
   
   
   describe Taggart::String, "Smart tags" do
+    include Taggart::API
+
     context "href tags" do
       it "renders a basic <a href>-tag." do 
-        "/hello/world.html".href("Hello World").should == "<a href=\"/hello/world.html\">Hello World</a>"
+        taggart("/hello/world.html").href("Hello World").to_s.should == "<a href=\"/hello/world.html\">Hello World</a>"
       end
       
       it "renders a basic <a href>-tag without an explicit label." do 
-        "/hello/world.html".href.should == "<a href=\"/hello/world.html\">/hello/world.html</a>"
+        taggart("/hello/world.html").href.to_s.should == "<a href=\"/hello/world.html\">/hello/world.html</a>"
       end
       
       it "renders a <a href>-tag with an attribute." do 
-        "/hello/world.html".href("Hello World", {class: :linky}).should == "<a class=\"linky\" href=\"/hello/world.html\">Hello World</a>"
+        taggart("/hello/world.html").href("Hello World", {class: :linky}).to_s.should == "<a class=\"linky\" href=\"/hello/world.html\">Hello World</a>"
       end
       
       it "renders a <a href>-tag with an attribute, but without an explicit label." do 
-        "/hello/world.html".href(nil, {class: :linky}).should == "<a class=\"linky\" href=\"/hello/world.html\">/hello/world.html</a>"
+        taggart("/hello/world.html").href(nil, {class: :linky}).to_s.should == "<a class=\"linky\" href=\"/hello/world.html\">/hello/world.html</a>"
       end
       
       it "renders a <a href>-tag with two attributes." do 
-        "/hello/world.html".href("Hello World", {class: :linky, title: 'Clicky the linky!'}).should == "<a class=\"linky\" title=\"Clicky the linky!\" href=\"/hello/world.html\">Hello World</a>"
+        taggart("/hello/world.html").href("Hello World", {class: :linky, title: 'Clicky the linky!'}).to_s.should == "<a class=\"linky\" title=\"Clicky the linky!\" href=\"/hello/world.html\">Hello World</a>"
       end
     end
     
     context "img tags" do 
       it "renders a basic <img>-tag." do
-        "/path/to/img.png".img.should == "<img src=\"/path/to/img.png\" />"
+        taggart("/path/to/img.png").img.to_s.should == "<img src=\"/path/to/img.png\" />"
       end
       
       it "renders a <img>-tag with an attribute." do
-        "/path/to/img.png".img({class: :thumbnail}).should == "<img class=\"thumbnail\" src=\"/path/to/img.png\" />"
+        taggart("/path/to/img.png").img({class: :thumbnail}).to_s.should == "<img class=\"thumbnail\" src=\"/path/to/img.png\" />"
       end
       
       it "renders a <img>-tag with two attributes." do
-        "/path/to/img.png".img({class: :slideshow, alt: :'Rainbows and fluffy animals'}).should == "<img class=\"slideshow\" alt=\"Rainbows and fluffy animals\" src=\"/path/to/img.png\" />"
+        taggart("/path/to/img.png").img({class: :slideshow, alt: :'Rainbows and fluffy animals'}).to_s.should == "<img class=\"slideshow\" alt=\"Rainbows and fluffy animals\" src=\"/path/to/img.png\" />"
       end
     end
     
     context "script tags" do
       it "should render a script tag with src-attribute when the string ends in .js" do
-        "/jabbarscript/waste_cpu_cycles.js".script.should == "<script type=\"text/javascript\" src=\"/jabbarscript/waste_cpu_cycles.js\"></script>"
+        taggart("/jabbarscript/waste_cpu_cycles.js").script.to_s.should == "<script type=\"text/javascript\" src=\"/jabbarscript/waste_cpu_cycles.js\"></script>"
       end
       
       it "should render a script tag with src-attribute and an id-attribute  when the string ends in .js" do
-        "/jabbarscript/fancy_pants.js".script(id: 'fancy_fancy').should == "<script id=\"fancy_fancy\" type=\"text/javascript\" src=\"/jabbarscript/fancy_pants.js\"></script>"
+        taggart("/jabbarscript/fancy_pants.js").script(id: 'fancy_fancy').to_s.should == "<script id=\"fancy_fancy\" type=\"text/javascript\" src=\"/jabbarscript/fancy_pants.js\"></script>"
       end
       
       it "should render a script tag with when the string does not ends in .js" do
-        "document.write(\"Hello World!\");".script(id: 'pants_pants').should == "<script id=\"pants_pants\" type=\"text/javascript\">document.write(\"Hello World!\");</script>"
+        taggart("document.write(\"Hello World!\");").script(id: 'pants_pants').to_s.should == "<script id=\"pants_pants\" type=\"text/javascript\">document.write(\"Hello World!\");</script>"
       end
     end
     
     context "combinations" do
       it "renders a clickable image" do
-        "/path/to/img.png".img({class: :thumbnail}).a(href: '/hello/world.html').should == "<a href=\"/hello/world.html\"><img class=\"thumbnail\" src=\"/path/to/img.png\" /></a>"
+        taggart("/path/to/img.png").img({class: :thumbnail}).a(href: '/hello/world.html').to_s.should == "<a href=\"/hello/world.html\"><img class=\"thumbnail\" src=\"/path/to/img.png\" /></a>"
       end
     end
 
     it "responds to htji" do
-      "Hello World!".htji.should == %w{72 101 108 108 111 32 116 111 32 74 97 115 111 110 32 73 115 97 97 99 115 33}.map { |c| c.to_i.chr }.join.h1
+      taggart("Hello World!").htji.to_s.should == taggart(%w{72 101 108 108 111 32 116 111 32 74 97 115 111 110 32 73 115 97 97 99 115 33}.map { |c| c.to_i.chr }.join).h1.to_s
     end
   end
   
   describe Taggart::Array, "smarter tags" do
+    include Taggart::API
+
     context "cleverer lists" do
       it "returns an ordered list when calling ol." do
-        %w{one two three}.ol.should == "<ol><li>one</li><li>two</li><li>three</li></ol>"
+        taggart(%w{one two three}).ol.to_s.should == "<ol><li>one</li><li>two</li><li>three</li></ol>"
       end
       
       it "returns an ordered list with attributes when calling ol." do
-        %w{one two three}.ol(id: :my_unordered_list).should == "<ol id=\"my_unordered_list\"><li>one</li><li>two</li><li>three</li></ol>"
+        taggart(%w{one two three}).ol(id: :my_unordered_list).to_s.should == "<ol id=\"my_unordered_list\"><li>one</li><li>two</li><li>three</li></ol>"
       end
       
       it "returns an unordered list when calling ul." do
-        %w{one two three}.ul.should == "<ul><li>one</li><li>two</li><li>three</li></ul>"
+        taggart(%w{one two three}).ul.to_s.should == "<ul><li>one</li><li>two</li><li>three</li></ul>"
       end
       
       it "returns an unordered list with attributes when calling ol." do
-        %w{one two three}.ul(id: :my_ordered_list).should == "<ul id=\"my_ordered_list\"><li>one</li><li>two</li><li>three</li></ul>"
+        taggart(%w{one two three}).ul(id: :my_ordered_list).to_s.should == "<ul id=\"my_ordered_list\"><li>one</li><li>two</li><li>three</li></ul>"
       end
       
     end
     
     context "cleverer tables" do
       it "returns a table row when calling tr." do
-        %w{one two three}.tr.should == "<tr><td>one</td><td>two</td><td>three</td></tr>"
+        taggart(%w{one two three}).tr.to_s.should == "<tr><td>one</td><td>two</td><td>three</td></tr>"
       end
       
       it "returns a table row witth attributes when calling tr." do
-        %w{one two three}.tr(id: :my_table_row).should == "<tr id=\"my_table_row\"><td>one</td><td>two</td><td>three</td></tr>"
+        taggart(%w{one two three}).tr(id: :my_table_row).to_s.should == "<tr id=\"my_table_row\"><td>one</td><td>two</td><td>three</td></tr>"
       end
       
       it "returns a single row table when calling table with strings." do
-        %w{one two three}.table.should == "<table><tr><td>one</td><td>two</td><td>three</td></tr></table>"
+        taggart(%w{one two three}).table.to_s.should == "<table><tr><td>one</td><td>two</td><td>three</td></tr></table>"
       end
       
       it "returns a single row table with attributes when calling table with strings." do
-        %w{one two three}.table(id: :single_row).should == "<table id=\"single_row\"><tr><td>one</td><td>two</td><td>three</td></tr></table>"
+        taggart(%w{one two three}).table(id: :single_row).to_s.should == "<table id=\"single_row\"><tr><td>one</td><td>two</td><td>three</td></tr></table>"
       end
       
       it "returns a multi-row table when calling table with multidimensional arrays" do
-        [%w(one two three), %w(zero nine eight)].table.should == "<table><tr><td>one</td><td>two</td><td>three</td></tr><tr><td>zero</td><td>nine</td><td>eight</td></tr></table>"
+        taggart([%w(one two three), %w(zero nine eight)]).table.to_s.should == "<table><tr><td>one</td><td>two</td><td>three</td></tr><tr><td>zero</td><td>nine</td><td>eight</td></tr></table>"
       end
       
       it "returns a multi-row table with attributes when calling table with multidimensional arrays" do
-        [%w(one two three), %w(zero nine eight)].table(id: :multi_row).should == "<table id=\"multi_row\"><tr><td>one</td><td>two</td><td>three</td></tr><tr><td>zero</td><td>nine</td><td>eight</td></tr></table>"
+        taggart([%w(one two three), %w(zero nine eight)]).table(id: :multi_row).to_s.should == "<table id=\"multi_row\"><tr><td>one</td><td>two</td><td>three</td></tr><tr><td>zero</td><td>nine</td><td>eight</td></tr></table>"
       end
     end
   end

--- a/spec/lib/taggart_spec.rb
+++ b/spec/lib/taggart_spec.rb
@@ -204,7 +204,7 @@ describe Taggart::Array, "#array_attribute_tag" do
     end
     
     it "executes substitute-sub when the fourth example, with a regexp, from the documentation is passed in" do
-      'Is SHELL your preferred shell?'.sub(/[[:upper:]]{2,}/, ENV).should == "Is /bin/bash your preferred shell?"
+      'Is SHELL your preferred shell?'.sub(/[[:upper:]]{2,}/, { 'SHELL' => '/bin/bash' }).should == "Is /bin/bash your preferred shell?"
     end
     
     it "executes substitute-sub when the fifth example, with a regexp, from the documentation is passed in" do

--- a/taggart.gemspec
+++ b/taggart.gemspec
@@ -13,6 +13,7 @@ Gem::Specification.new do |s|
   s.require_paths = ["lib"]
   s.files         = ["lib/taggart.rb", "lib/taggart_help.rb", "Rakefile", "taggart.gemspec", "README.markdown"]
   s.test_files    = ["spec/lib/taggart_spec.rb"]
-  s.add_development_dependency ["rake", "rspec", "guard", "guard-rspec", "rb-fsevent"] # rb-fsevent is only required on MacOS.
+  s.add_development_dependency "rake"
+  s.add_development_dependency "rspec"
   s.post_install_message = "Thanks for showing interest in Taggart! Please provide feedback to jocke@selincite.com!"
 end


### PR DESCRIPTION
I probably ought to have split some of these commits into their own pull requests, but I was in a rush! The main changes are in this commit - 0614df697f5e1a261e237c1d961c428732179624. One of the nicest things about this approach is that you no longer need to worry about the "special" tags where tag names collide with existing method names.

Please don't feel under any pressure to incorporate these changes - I just wanted to demonstrate the different approach which was briefly discussed at OXRUG.

Obviously there's a downside to these changes in that they make the code slightly more verbose, but in my experience monkey-patching built-in classes tends to lead to nasty problems down the road!

The first three commits are less controversial and so you might be more comfortable incorporating those.
- 650a8bfdacb514c2e7bcf9f8fc60adbd15a9e261
- 2b07b5c4f1702ba263f45cb909838e2a2bc7fd65
- 0da9aa052e6eac6da674ef1ea28996f0d1b9bfb9

I'd be happy to supply them in a separate PR if you were interested.
